### PR TITLE
Throw KeyError instead of error

### DIFF
--- a/src/smalldict.jl
+++ b/src/smalldict.jl
@@ -194,7 +194,7 @@ Base.hasfastin(::Type{D}) where D <: AbstractSmallDict = Base.hasfastin(fieldtyp
 function getindex(d::AbstractSmallDict, key)
     i = token(d, key)
     if i === nothing
-        error("key not found")
+        throw(KeyError(key))
     else
         @inbounds d.vals[i]
     end


### PR DESCRIPTION
Traditional Dict implementations throw `KeyError` instead of the more generic `error`. I wasn't sure if it made sense to also throw it for `invget` since that's not part of the normal Dict implementation.

(Very cool package btw; love the concepts/ideas!)