### PR TITLE
use BMI2 instruction pdep for faster access to nth bit of SmallBitSet

### DIFF
--- a/src/SmallCollections.jl
+++ b/src/SmallCollections.jl
@@ -115,8 +115,18 @@ ntuple(f, n) = Base.ntuple(f, n)
 @noinline keyerror(key) = throw(KeyError(key))
 @noinline dimensionmismatch(msg) = throw(DimensionMismatch(msg))
 @noinline overflowerror(msg) = throw(OverflowError(msg))
+@noinline boundserror(itr, n) = throw(BoundsError(itr, n))
 
 include("bits.jl")
+
+if Sys.ARCH in (:x86_64, :i686)
+    include("arch/x86_init.jl")
+else
+    const HAS_BEXTR = false
+    const HAS_PEXT = false
+    const HAS_COMPRESS = false
+end
+
 include("mapstyle.jl")
 
 include("smallbitset.jl")
@@ -134,10 +144,6 @@ include("smallset.jl")
 if Sys.ARCH in (:x86_64, :i686)
     include("arch/x86.jl")
 else
-    const HAS_BEXTR = false
-    const HAS_PEXT = false
-    const HAS_COMPRESS = false
-
     hasshuffle(::Val, ::Type, ::Val) = false
 end
 

--- a/src/arch/x86.jl
+++ b/src/arch/x86.jl
@@ -1,40 +1,5 @@
 using CpuId: cpufeature
 
-if cpufeature(:BMI1)
-    const llvm_bextr = "llvm.x86.bmi.bextr.$(bitsize(UInt))"
-
-    bextr(x::U, y::Unsigned) where U <: Union{UInt8,UInt16,UInt32,UInt} =
-        ccall((llvm_bextr,), llvmcall, UInt, (UInt, UInt), x % UInt, y % UInt) % U
-
-    const HAS_BEXTR = true
-else
-    const HAS_BEXTR = false
-end
-
-if cpufeature(:BMI2)
-    const llvm_pdep = "llvm.x86.bmi.pdep.$(bitsize(UInt))"
-    const llvm_pext = "llvm.x86.bmi.pext.$(bitsize(UInt))"
-
-    pdep(x::Unsigned, y::U) where U <: Union{UInt8,UInt16,UInt32,UInt} =
-        ccall((llvm_pdep,), llvmcall, UInt, (UInt, UInt), x % UInt, y % UInt) % U
-
-    pext(x::Unsigned, y::U) where U <: Union{UInt8,UInt16,UInt32,UInt} =
-        ccall((llvm_pext,), llvmcall, UInt, (UInt, UInt), x % UInt, y % UInt) % U
-
-    function Random.nth(s::SmallBitSet{U}, n::Integer) where U <: Union{UInt8,UInt16,UInt32,UInt}
-        b = pdep(unsafe_shl(one(U), n-1), bits(s))
-        return trailing_zeros(b) + 1
-    end
-
-    const HAS_PEXT = true
-else
-    const HAS_PEXT = false
-end
-
-using CpuId: CpuFeature, __ECX
-const AVX512VBMI2 = CpuFeature(0x0000_0007, 0x00, __ECX, 6)
-const HAS_COMPRESS = cpufeature(:AVX512VL) || cpufeature(AVX512VBMI2)
-
 @inline @generated function shuffle(::Val{:avx}, v::AbstractFixedVector{N,T}, p::AbstractFixedVector{N,U}, @nospecialize(_)) where {N, T, U}
     @assert N*sizeof(T) == N*sizeof(U) == 16
     HT = hwtype(T)

--- a/src/arch/x86.jl
+++ b/src/arch/x86.jl
@@ -21,6 +21,11 @@ if cpufeature(:BMI2)
     pext(x::Unsigned, y::U) where U <: Union{UInt8,UInt16,UInt32,UInt} =
         ccall((llvm_pext,), llvmcall, UInt, (UInt, UInt), x % UInt, y % UInt) % U
 
+    function Random.nth(s::SmallBitSet{U}, n::Integer) where U <: Union{UInt8,UInt16,UInt32,UInt}
+        b = pdep(unsafe_shl(one(U), n-1), bits(s))
+        return trailing_zeros(b) + 1
+    end
+
     const HAS_PEXT = true
 else
     const HAS_PEXT = false

--- a/src/arch/x86_init.jl
+++ b/src/arch/x86_init.jl
@@ -1,0 +1,30 @@
+using CpuId: cpufeature, CpuFeature, __ECX
+
+if cpufeature(:BMI1)
+    const llvm_bextr = "llvm.x86.bmi.bextr.$(bitsize(UInt))"
+
+    bextr(x::U, y::Unsigned) where U <: Union{UInt8,UInt16,UInt32,UInt} =
+        ccall((llvm_bextr,), llvmcall, UInt, (UInt, UInt), x % UInt, y % UInt) % U
+
+    const HAS_BEXTR = true
+else
+    const HAS_BEXTR = false
+end
+
+if cpufeature(:BMI2)
+    const llvm_pdep = "llvm.x86.bmi.pdep.$(bitsize(UInt))"
+    const llvm_pext = "llvm.x86.bmi.pext.$(bitsize(UInt))"
+
+    pdep(x::Unsigned, y::U) where U <: Union{UInt8,UInt16,UInt32,UInt} =
+        ccall((llvm_pdep,), llvmcall, UInt, (UInt, UInt), x % UInt, y % UInt) % U
+
+    pext(x::Unsigned, y::U) where U <: Union{UInt8,UInt16,UInt32,UInt} =
+        ccall((llvm_pext,), llvmcall, UInt, (UInt, UInt), x % UInt, y % UInt) % U
+
+    const HAS_PEXT = true
+else
+    const HAS_PEXT = false
+end
+
+const AVX512VBMI2 = CpuFeature(0x0000_0007, 0x00, __ECX, 6)
+const HAS_COMPRESS = cpufeature(:AVX512VL) || cpufeature(AVX512VBMI2)

--- a/src/smallbitset.jl
+++ b/src/smallbitset.jl
@@ -254,6 +254,14 @@ SmallBitSet{UInt8}([])
 """
 first_as_set(s::SmallBitSet) = _SmallBitSet(blsi(s.mask))
 
+if VERSION > v"1.13-" && HAS_PEXT
+    @inline function Iterators.nth(s::SmallBitSet{U}, n::Integer) where U <: Union{UInt8,UInt16,UInt32,UInt}
+        @boundscheck 1 <= n <= length(s) || boundserror(s, n)
+        b = pdep(unsafe_shl(one(U), n-1), bits(s))
+        return trailing_zeros(b) + 1
+    end
+end
+
 function minimum(s::SmallBitSet; init = missing)
     if !isempty(s)
         @inbounds first(s)

--- a/test/smallbitset.jl
+++ b/test/smallbitset.jl
@@ -178,3 +178,15 @@ end
     v = rand(SmallBitSet{UInt16}, 50)
     @test sort(v) == sort(v; lt = colex_lt)  # does UIntMappable work?
 end
+
+VERSION > v"1.13-" && @testset "SmallBitSet nth" begin
+    for U in [UInt8, UInt16, UInt32, UInt]
+        s = rand(SmallBitSet{U})
+        v = collect(s)
+        for i in 1:length(s)
+            @test_inferred Iterators.nth(s, i) v[i]
+        end
+        @test_throws BoundsError Iterators.nth(s, 0)
+        @test_throws BoundsError Iterators.nth(s, length(s)+1)
+    end
+end


### PR DESCRIPTION
Implement `Random.nth` using `pdep` when available to speed up random lookup into `SmallBitSet`.
Speeds up `rand(s::SmallBitSet)`

Some notes:
`pdep` could also be used to implement `getindex` for `SmallBitSet`. Not sure if that's useful for a set, unless it's treated as an ordered set I guess.
 
I originally tried to place `Random.nth` method into `smallbitset.jl` just after `Random.rand` definitions, as this seems the logical place for it.
However, I couldn't really resolve the circular dependencies cleanly.
I tried guarding the method definition with something like:
```
    if HAS_PEXT     # maybe HAS_BMI2 is a better name for this const?
    if Sys.ARCH in (:x86_64, :i686) && cpufeature(:BMI2)
    if isdefined(SmallCollections, :pdep)
```
but these are not yet defined because `smallbitsets.jl` is executed before `arch/x86.jl`
I tried rearranging the execution order but it just created a different set of circular dependencies.

I suspect there might be better ways to implement. I'm happy to take some guidance here, or drop the PR entirely.

Here's some benchmarking.
```
using SmallCollections, Random, BenchmarkTools
s = SmallBitSet([1, 5, 56])
rng = Xoshiro()
rand(rng, s)
@benchmark rand($rng, $s)
```

Without `pdep` (before PR):
```
BenchmarkTools.Trial: 10000 samples with 1000 evaluations per sample.
 Range (min … max):  10.400 ns … 21.200 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     10.800 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   10.917 ns ±  0.967 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%
```

With `pdep` (after PR):
```
BenchmarkTools.Trial: 10000 samples with 1000 evaluations per sample.
 Range (min … max):  5.300 ns … 19.200 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     5.400 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   5.461 ns ±  0.673 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%
```