### PR TITLE
fix SmallBitSet edge case with union/symdiff

### DIFF
--- a/src/smallbitset.jl
+++ b/src/smallbitset.jl
@@ -588,7 +588,7 @@ union(s::SmallBitSet, t::SmallBitSet) = _SmallBitSet(s.mask | t.mask)
 
 union(s::SmallBitSet, ts::SmallBitSet...) = foldl(union, ts; init = s)
 
-union(s::SmallBitSet, t) = foldl(push, t; init = s)
+union(s::SmallBitSet, t::Integer) = push(s,t)
 
 intersect(s::SmallBitSet{U}, t::SmallBitSet) where U <: Unsigned = _SmallBitSet(s.mask & (t.mask % U))
 
@@ -626,17 +626,7 @@ symdiff(s::SmallBitSet, t::SmallBitSet) = _SmallBitSet(s.mask ⊻ t.mask)
 
 symdiff(s::SmallBitSet, ts::SmallBitSet...) = foldl(symdiff, ts; init = s)
 
-function symdiff(s::SmallBitSet, t)
-    u=s
-    for n in t
-        if n in s
-            u = delete(u, n)
-        else
-            u = push(u, n)
-        end
-    end
-    u
-end
+symdiff(s::SmallBitSet, t::Integer) = t in s ? delete(s, t) : push(s, t)
 
 
 Random.rand(rng::AbstractRNG, ::SamplerType{SmallBitSet{U}}) where U <: Unsigned = _SmallBitSet(rand(rng, U))

--- a/src/smallbitset.jl
+++ b/src/smallbitset.jl
@@ -588,6 +588,8 @@ union(s::SmallBitSet, t::SmallBitSet) = _SmallBitSet(s.mask | t.mask)
 
 union(s::SmallBitSet, ts::SmallBitSet...) = foldl(union, ts; init = s)
 
+union(s::SmallBitSet, t) = foldl(push, t; init = s)
+
 intersect(s::SmallBitSet{U}, t::SmallBitSet) where U <: Unsigned = _SmallBitSet(s.mask & (t.mask % U))
 
 function intersect(s::SmallBitSet{U}, t) where U <: Unsigned
@@ -623,6 +625,19 @@ setdiff(s::SmallBitSet, ts...) = foldl(setdiff, ts; init = s)
 symdiff(s::SmallBitSet, t::SmallBitSet) = _SmallBitSet(s.mask ⊻ t.mask)
 
 symdiff(s::SmallBitSet, ts::SmallBitSet...) = foldl(symdiff, ts; init = s)
+
+function symdiff(s::SmallBitSet, t)
+    u=s
+    for n in t
+        if n in s
+            u = delete(u, n)
+        else
+            u = push(u, n)
+        end
+    end
+    u
+end
+
 
 Random.rand(rng::AbstractRNG, ::SamplerType{SmallBitSet{U}}) where U <: Unsigned = _SmallBitSet(rand(rng, U))
 Random.rand(rng::AbstractRNG, ::SamplerType{SmallBitSet}) = rand(rng, SmallBitSet{UInt})


### PR DESCRIPTION
Hi @matthias314 

I just wanted to try and fix edge case I found with calculating a `union` or `symdiff` of a `SmallBitSet` and an `Int`. For these functions the output was being converted to a Set. 

```julia
julia> a = SmallBitSet(1:3)
SmallBitSet{UInt64} with 3 elements:
  1
  2
  3

julia> intersect(a,3)   #works fine
SmallBitSet{UInt64} with 1 element:
  3

julia> setdiff(a,3)   #looks good
SmallBitSet{UInt64} with 2 elements:
  1
  2

julia> union(a,3)   #unexpected
Set{Int64} with 3 elements:
  2
  3
  1
  
 julia> symdiff(a,3)   #also unexpected
Set{Int64} with 2 elements:
  2
  1
```

The same behavior was happening when trying to `union` or `symdiff` a `SmallBitSet` and a `Vector{Int}`. Here are what the outputs look like this with PR:

```julia
julia> a = SmallBitSet(1:3)
SmallBitSet{UInt64} with 3 elements:
  1
  2
  3

julia> union(a,3)
SmallBitSet{UInt64} with 3 elements:
  1
  2
  3

julia> union(a,4)
SmallBitSet{UInt64} with 4 elements:
  1
  2
  3
  4

julia> union(a,[3,4])
SmallBitSet{UInt64} with 4 elements:
  1
  2
  3
  4

julia> symdiff(a,3)
SmallBitSet{UInt64} with 2 elements:
  1
  2

julia> symdiff(a,4)
SmallBitSet{UInt64} with 4 elements:
  1
  2
  3
  4

julia> symdiff(a,[3,4])
SmallBitSet{UInt64} with 3 elements:
  1
  2
  4
```